### PR TITLE
fix: use custom helper to set window local options

### DIFF
--- a/lua/satellite.lua
+++ b/lua/satellite.lua
@@ -274,15 +274,14 @@ local function create_view(config)
 
   local winid = api.nvim_open_win(bufnr, false, config)
 
+  local util = require('satellite.util')
   -- It's not sufficient to just specify Normal highlighting. With just that, a
   -- color scheme's specification of EndOfBuffer would be used to color the
   -- bottom of the scrollbar.
-  require('satellite.util').win_set_local_options(winid, {
-    winhighlight = 'Normal:Normal',
-    winblend = user_config.winblend,
-    foldcolumn = '0',
-    wrap = false,
-  })
+  util.set_window_option(winid, "winhighlight", 'Normal:Normal')
+  util.set_window_option(winid, "winblend", user_config.winblend)
+  util.set_window_option(winid, "foldcolumn" , '0')
+  util.set_window_option(winid, "wrap" , false)
 
   return bufnr, winid
 end

--- a/lua/satellite.lua
+++ b/lua/satellite.lua
@@ -277,10 +277,12 @@ local function create_view(config)
   -- It's not sufficient to just specify Normal highlighting. With just that, a
   -- color scheme's specification of EndOfBuffer would be used to color the
   -- bottom of the scrollbar.
-  vim.wo[winid].winhighlight = 'Normal:Normal'
-  vim.wo[winid].winblend = user_config.winblend
-  vim.wo[winid].foldcolumn = '0'
-  vim.wo[winid].wrap = false
+  require('satellite.util').win_set_local_options(winid, {
+    winhighlight = 'Normal:Normal',
+    winblend = user_config.winblend,
+    foldcolumn = '0',
+    wrap = false,
+  })
 
   return bufnr, winid
 end

--- a/lua/satellite/util.lua
+++ b/lua/satellite/util.lua
@@ -2,24 +2,26 @@
 local M = {}
 
 -- NOTE:
+-- Set window option.
 -- Workaround for nvim bug where nvim_win_set_option "leaks" local
 -- options to windows created afterwards (thanks @sindrets!)
 -- SEE:
 -- https://github.com/b0o/incline.nvim/issues/4
 -- https://github.com/neovim/neovim/issues/18283
 -- https://github.com/neovim/neovim/issues/14670
-function M.win_set_local_options(win, opts)
-  a.nvim_win_call(win, function()
-    for opt, val in pairs(opts) do
-      local arg
-      if type(val) == 'boolean' then
-        arg = (val and '' or 'no') .. opt
-      else
-        arg = opt .. '=' .. val
-      end
-      vim.cmd('setlocal ' .. arg)
+-- https://github.com/neovim/neovim#9110
+function M.set_window_option(winid, key, value)
+    -- Convert to Vim format (e.g., 1 instead of Lua true).
+    if value == true then
+      value = 1
+    elseif value == false then
+      value = 0
     end
-  end)
+    -- setwinvar(..., '&...', ...) is used in place of nvim_win_set_option
+    -- to avoid Neovim Issues #15529 and #15531, where the global window option
+    -- is set in addition to the window-local option, when using Neovim's API or
+    -- Lua interface.
+    vim.fn.setwinvar(winid, '&' .. key, value)
 end
 
 

--- a/lua/satellite/util.lua
+++ b/lua/satellite/util.lua
@@ -1,6 +1,28 @@
 
 local M = {}
 
+-- NOTE:
+-- Workaround for nvim bug where nvim_win_set_option "leaks" local
+-- options to windows created afterwards (thanks @sindrets!)
+-- SEE:
+-- https://github.com/b0o/incline.nvim/issues/4
+-- https://github.com/neovim/neovim/issues/18283
+-- https://github.com/neovim/neovim/issues/14670
+function M.win_set_local_options(win, opts)
+  a.nvim_win_call(win, function()
+    for opt, val in pairs(opts) do
+      local arg
+      if type(val) == 'boolean' then
+        arg = (val and '' or 'no') .. opt
+      else
+        arg = opt .. '=' .. val
+      end
+      vim.cmd('setlocal ' .. arg)
+    end
+  end)
+end
+
+
 function M.debounce_trailing(f, ms)
   local timer = vim.loop.new_timer()
   return function(...)


### PR DESCRIPTION
Due to an existing bug in nvim that causes window options set via `vim.wo` or `nvim_set_option` these settings bleed into subsequent windows. I've encountered this bug across a few different plugins, and this is the simplest solution that the author of incline.nvim implemented.

<img width="818" alt="Screen Shot 2022-05-11 at 12 53 44" src="https://user-images.githubusercontent.com/22454918/167833587-afe87855-0bec-4776-99f3-fd3379c3cb76.png">

