### PR TITLE
fix(marks): check config is not nil

### DIFF
--- a/lua/satellite/handlers/marks.lua
+++ b/lua/satellite/handlers/marks.lua
@@ -58,7 +58,7 @@ function handler.update(bufnr, winid)
 
     local pos = util.row_to_barpos(winid, lnum-1)
 
-    if config.show_builtins or not mark_is_builtin(mark.mark) then
+    if config and config.show_builtins or not mark_is_builtin(mark.mark) then
       marks[pos] = {
         -- first char of mark name is a single quote
         symbol = string.sub(mark.mark, 2, 3),


### PR DESCRIPTION
Whilst trying to disable one of the handlers in my config I encountered this error. I don't know the root cause as I'm not familiar with the code base but it appears the config object might be being re-assigned to `nil` somewhere. I'm able to reproduce this consistently in my config using the following setup:

```lua
    use({
      'lewis6991/satellite.nvim',
      config = function()
          require('satellite').setup({
           handlers = {
              gitsigns = {
                enable = false,
              },
            },
            excluded_filetypes = {
              'packer',
              'neo-tree',
              'norg',
              'neo-tree-popup',
              'dapui_scopes',
              'dapui_stacks',
            },
          })
      end,
    })

```

```
Error detected while processing WinScrolled Autocommands for "*":                                  
Error executing lua callback: ...er/start/satellite.nvim/lua/satellite/handlers/marks.lua:61: attem
pt to index upvalue 'config' (a nil value)                                                         
stack traceback:                                                                                   
        ...er/start/satellite.nvim/lua/satellite/handlers/marks.lua:61: in function 'update'       
        ...ack/packer/start/satellite.nvim/lua/satellite/render.lua:49: in function 'render_handler
'                                                                                                  
        ...ack/packer/start/satellite.nvim/lua/satellite/render.lua:105: in function 'render_bar'  
        .../site/pack/packer/start/satellite.nvim/lua/satellite.lua:224: in function 'show_scrollba
r'                                                                                                 
        .../site/pack/packer/start/satellite.nvim/lua/satellite.lua:443: in function <.../site/pack
/packer/start/satellite.nvim/lua/satellite.lua:440> 
```

There might very well be a better solution for this but checking a table exists before accessing it didn't seem like too harmful a solution and prevents quite a blocking issue since it happens on winscrolled so is somewhat unavoidable