### PR TITLE
Fix issues with marks

### DIFF
--- a/lua/satellite/handlers/marks.lua
+++ b/lua/satellite/handlers/marks.lua
@@ -1,4 +1,5 @@
 local util = require'satellite.util'
+local view = require'satellite.view'
 
 local highlight = 'Normal'
 
@@ -11,10 +12,6 @@ local BUILTIN_MARKS = { "'.", "'^", "''", "'\"", "'<", "'>", "'[", "']" }
 
 local config = {}
 
-local function refresh()
-  require('satellite').refresh_bars()
-end
-
 ---@param m string mark name
 ---@return boolean
 local function mark_is_builtin(m)
@@ -26,57 +23,74 @@ local function mark_is_builtin(m)
   return false
 end
 
-function handler.init(config0)
-  config = config0
-
-  -- range over a-z
-  for char = 97, 122 do
-    local map = 'm' .. string.char(char)
+---@param m string mark name
+local function mark_set_keymap(m)
+    local map = 'm' .. m
     ---@diagnostic disable-next-line: missing-parameter
     if vim.fn.maparg(map) == "" then
       vim.keymap.set({ 'n', 'v' }, map, function()
-        vim.schedule(refresh)
-        return map
-      end, { unique = true, expr = true })
+        local bufnr = vim.api.nvim_get_current_buf()
+        local line, col = unpack(vim.api.nvim_win_get_cursor(0))
+        local mline, mcol = unpack(vim.api.nvim_buf_get_mark(bufnr, m))
+        if mline == line and mcol == col then
+            vim.api.nvim_buf_del_mark(bufnr, m)
+        else
+            vim.api.nvim_buf_set_mark(bufnr, m, line, col, {})
+        end
+        vim.schedule(view.refresh_bars)
+      end)
     end
+end
+
+function handler.init(config0)
+  config = config0
+
+  -- range over A-Z
+  for code = 65, 90 do
+    mark_set_keymap(string.char(code))
+  end
+
+  -- -- range over a-z
+  for code = 97, 122 do
+    mark_set_keymap(string.char(code))
   end
 
   local group = vim.api.nvim_create_augroup('satellite_marks', {})
-
   for _, cmd in ipairs{'k', 'mar', 'delm'} do
     util.on_cmd(cmd, group, function()
-      vim.schedule(function()
-        require('satellite.view').refresh_bars()
-      end)
+      vim.schedule(view.refresh_bars)
     end)
   end
 
 end
 
-function handler.update(bufnr, winid)
-  local marks = {}
-  local buffer_marks = vim.fn.getmarklist(bufnr)
-  for _, mark in ipairs(buffer_marks) do
+local function add_mark_to_bar(marks, mark, winid)
     local lnum = mark.pos[2]
-
     local pos = util.row_to_barpos(winid, lnum-1)
 
     if config and config.show_builtins or not mark_is_builtin(mark.mark) then
-      marks[pos] = {
-        -- first char of mark name is a single quote
-        symbol = string.sub(mark.mark, 2, 3),
-      }
+        marks[#marks+1] = {
+            pos = pos,
+            highlight = highlight,
+            -- first char of mark name is a single quote
+            symbol = string.sub(mark.mark, 2, 3),
+        }
+    end
+end
+
+function handler.update(bufnr, winid)
+  local ret = {}
+
+  local current_file = vim.api.nvim_buf_get_name(bufnr)
+  for _, mark in ipairs(vim.fn.getmarklist()) do
+    local mark_file = vim.fn.fnamemodify(mark.file, ':p:a')
+    if mark_file == current_file and mark.mark:find('[a-zA-Z]') ~= nil then
+        add_mark_to_bar(ret, mark, winid)
     end
   end
 
-  local ret = {}
-
-  for pos, mark in pairs(marks) do
-    ret[#ret+1] = {
-      pos = pos,
-      highlight = highlight,
-      symbol = mark.symbol,
-    }
+  for _, mark in ipairs(vim.fn.getmarklist(bufnr)) do
+    add_mark_to_bar(ret, mark, winid)
   end
 
   return ret

--- a/lua/satellite/handlers/marks.lua
+++ b/lua/satellite/handlers/marks.lua
@@ -29,16 +29,9 @@ local function mark_set_keymap(m)
     ---@diagnostic disable-next-line: missing-parameter
     if vim.fn.maparg(map) == "" then
       vim.keymap.set({ 'n', 'v' }, map, function()
-        local bufnr = vim.api.nvim_get_current_buf()
-        local line, col = unpack(vim.api.nvim_win_get_cursor(0))
-        local mline, mcol = unpack(vim.api.nvim_buf_get_mark(bufnr, m))
-        if mline == line and mcol == col then
-            vim.api.nvim_buf_del_mark(bufnr, m)
-        else
-            vim.api.nvim_buf_set_mark(bufnr, m, line, col, {})
-        end
         vim.schedule(view.refresh_bars)
-      end)
+        return map
+      end, { unique = true, expr = true})
     end
 end
 


### PR DESCRIPTION
Hi, @lewis6991 . First of all, thanks you for this interesting plugin!

I'm actively using marks and found a several issues in this plugin related to the marks handler.

1. Global marks are not supported.
2. Adding marks doesn't work:
```
Error executing vim.schedule lua callback: ...er/start/satellite.nvim/lua/satellite/handlers/marks.lua:15: attempt to call field 'refresh_bars' (a nil value)
stack traceback:
        ...er/start/satellite.nvim/lua/satellite/handlers/marks.lua:15: in function <...er/start/satellite.nvim/lua/satellite/handlers/marks.lua:14>
```

**Point for discussion**:

Some people (including me) use third-party plugins to manage marks (e.g [vim-signature](https://github.com/kshenoy/vim-signature), [marks.nvim](https://github.com/chentoast/marks.nvim), [easymarks.nvim](https://github.com/0x00-ketsu/easymark.nvim)) or use custom key bindings to add/delete marks. I'm using vim-signature and the redefinition of `m<char>` binding conflicts with vim-signature functionality (mark toggling doesn't work). 
What do you think about using periodic mark polling instead of overriding keybindings?