### PR TITLE
fix: winbar not being included in window height calculations

### DIFF
--- a/lua/satellite/mouse.lua
+++ b/lua/satellite/mouse.lua
@@ -23,7 +23,7 @@ local function get_topline(winid, bufnr, row, bar_height)
     return 1
   end
 
-  local winheight = api.nvim_win_get_height(winid)
+  local winheight = util.get_winheight(winid)
   if row + bar_height >= winheight then
     -- If the scrollbar was dragged to the bottom of the window, always
     -- show the bottom line.
@@ -322,7 +322,7 @@ function M.handle_leftmouse()
       -- Only consider a scrollbar update for mouse events on windows (i.e.,
       -- not on the tabline or command line).
       if mouse_winid > 0 then
-        local winheight = api.nvim_win_get_height(winid)
+        local winheight = util.get_winheight(winid)
         local mouse_winrow = fn.getwininfo(mouse_winid)[1].winrow
         local winrow = fn.getwininfo(winid)[1].winrow
         local window_offset = mouse_winrow - winrow

--- a/lua/satellite/util.lua
+++ b/lua/satellite/util.lua
@@ -68,6 +68,17 @@ function M.invalidate_virtual_topline_lookup()
   virtual_topline_lookup_cache = defaulttable()
 end
 
+-- Returns the height of a window excluding the winbar
+function M.get_winheight(winid)
+  local winheight = api.nvim_win_get_height(winid)
+
+  if vim.wo[winid].winbar ~= '' then
+    winheight = winheight - 1
+  end
+
+  return winheight
+end
+
 -- Returns an array that maps window rows to the topline that corresponds to a
 -- scrollbar at that row under virtual satellite mode, in the current window.
 -- The computation primarily loops over lines, but may loop over virtual spans
@@ -77,7 +88,7 @@ function M.virtual_topline_lookup(winid)
     return virtual_topline_lookup_cache[winid]
   end
 
-  local winheight = api.nvim_win_get_height(winid)
+  local winheight = M.get_winheight(winid)
   local total_vlines = M.virtual_line_count(winid, 1)
   if not (total_vlines > 1 and winheight > 1) then
     virtual_topline_lookup_cache[winid] = {}
@@ -143,7 +154,7 @@ end
 function M.height_to_virtual(winid, row, row2)
   local vlinecount0 = M.virtual_line_count(winid, 1) - 1
   local vheight = M.virtual_line_count(winid, row, row2)
-  local winheight0 = api.nvim_win_get_height(winid) - 1
+  local winheight0 = M.get_winheight(winid) - 1
   return round(winheight0 * vheight / vlinecount0)
 end
 

--- a/lua/satellite/view.lua
+++ b/lua/satellite/view.lua
@@ -44,7 +44,7 @@ end
 ---@param row integer
 ---@param height integer
 local function render_scrollbar(winid, bbufnr, row, height)
-  local winheight = api.nvim_win_get_height(winid)
+  local winheight = util.get_winheight(winid)
 
   local lines = {}
   for i = 1, winheight do
@@ -169,14 +169,10 @@ local function show_scrollbar(winid)
     return
   end
 
-  local winheight = api.nvim_win_get_height(winid)
+  local winheight = util.get_winheight(winid)
   local winwidth = api.nvim_win_get_width(winid)
   if winheight == 0 or winwidth == 0 then
     return
-  end
-
-  if vim.o.winbar ~= '' then
-    winheight = winheight - 1
   end
 
   local line_count = api.nvim_buf_line_count(bufnr)


### PR DESCRIPTION
Fixes a few off by one rendering errors such as #18 and an unreported issue where when scrolling with the mouse the scroll bar is able to move off the screen by one

this utilizes the change in nightly https://github.com/neovim/neovim/issues/14090#issuecomment-1225699877

I am torn on if using the non api function or creating a new winbar aware utility function that utilizes the api is a better idea. I don't know how obscure the difference between `winheight()` and `nvim_win_get_height()` is. It might lead to confusion while reading the code :/