### PR TITLE
Fix: `m` have delay when it's modified by user

### DIFF
--- a/doc/satellite.txt
+++ b/doc/satellite.txt
@@ -39,6 +39,7 @@ of the default settings:
         },
         marks = {
           enable = true,
+          key =  'm',
           show_builtins = false, -- shows the builtin marks like [ ] < >
         },
       },

--- a/lua/satellite/autocmd/mark.lua
+++ b/lua/satellite/autocmd/mark.lua
@@ -5,6 +5,7 @@
 ---
 
 local util = require'satellite.util'
+local config = require'satellite.config'
 
 local api, fn = vim.api, vim.fn
 
@@ -19,7 +20,7 @@ local group = api.nvim_create_augroup('satellite_autocmd_mark', {})
 
 ---@param m string mark name
 local function mark_set_keymap(m)
-  local key = 'm' .. m
+  local key = config.user_config.handlers.marks.key .. m
   ---@diagnostic disable-next-line: missing-parameter
   if fn.maparg(key) == "" then
     vim.keymap.set({ 'n', 'v' }, key, function()

--- a/lua/satellite/config.lua
+++ b/lua/satellite/config.lua
@@ -14,6 +14,7 @@
 ---@field priority integer
 --
 ---@class MarksConfig
+---@field key    string
 ---@field enable boolean
 ---@field overlap boolean
 ---@field priority integer
@@ -53,6 +54,7 @@ local user_config = {
       priority = 20,
     },
     marks = {
+      key = 'm',
       enable = true,
       overlap = true,
       priority = 60,


### PR DESCRIPTION
If the user had modified the default `m` to other keymaps e.g. `nnoremap m %`, the satellite will remap the `m` and cause some delay.