### PR TITLE
fixed mouse not working when no scrollbar

### DIFF
--- a/lua/satellite/mouse.lua
+++ b/lua/satellite/mouse.lua
@@ -268,6 +268,7 @@ function M.handle_leftmouse()
 
         local props = view.get_props(mouse_winid)
         if not props then
+          fn.feedkeys(string.sub(input_string, str_idx), 'ni')
           return
         end
 


### PR DESCRIPTION
the function returns without properly handling the input, causes the mouse click lost when there is not a scrollbar