### PR TITLE
fix: won't update when closing certain windows

### DIFF
--- a/lua/satellite.lua
+++ b/lua/satellite.lua
@@ -32,6 +32,15 @@ local function enable()
   end})
 
   -- === Scrollbar Refreshing ===
+
+  -- The following one ensures that the scrollbar is correctly
+  -- updated after leaving a window.
+  api.nvim_create_autocmd("WinLeave", {
+    callback = function()
+      vim.defer_fn(view.refresh_bars, 0)
+    end
+  })
+
   api.nvim_create_autocmd({
     -- The following handles bar refreshing when changing the current window.
     'WinEnter', 'TermEnter',


### PR DESCRIPTION
It seems that the scrollbar does not update when closing some windows associated with plugins using the commands provided for this purpose (e.g. NvimTreeClose for nvim-tree on which I first encountered this error). I finally came up with this solution which is really not pretty but has the advantage of working.