### PR TITLE
fix(config): merge config with `tbl_deep_extend`

### DIFF
--- a/lua/satellite/config.lua
+++ b/lua/satellite/config.lua
@@ -75,7 +75,7 @@ M.user_config = setmetatable({}, {
 
 ---@param config Config
 function M.apply(config)
-  user_config = vim.tbl_extend('force', user_config, config or {})
+  user_config = vim.tbl_deep_extend('force', user_config, config or {})
 end
 
 return M


### PR DESCRIPTION
With this commit, users don't have to fill all the fields in handlers.

It also stops the error:
```
Vim(lua):E5108: Error executing lua .../lewis6991/satellite.nvim/lua/satellite/autocmd/mark.lua:23: attempt to concatenate field 'key' (a nil value)
stack traceback:
^I.../lewis6991/satellite.nvim/lua/satellite/autocmd/mark.lua:23: in function 'mark_set_keymap'
^I.../lewis6991/satellite.nvim/lua/satellite/autocmd/mark.lua:35: in main chunk
^I[C]: in function 'require'
^I...ewis6991/satellite.nvim/lua/satellite/handlers/marks.lua:8: in main chunk
^I[C]: in function 'require'
^I....com/lewis6991/satellite.nvim/lua/satellite/handlers.lua:53: in function 'init'
^I...os/github.com/lewis6991/satellite.nvim/lua/satellite.lua:133: in function <...os/github.com/lewis6991/satellite.nvim/lua/satellite.lua:130>
```