### PR TITLE
Allow configuration of handlers.gitsigns signs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ require('satellite').setup {
     },
     gitsigns = {
       enable = true,
+      signs = { -- can only be a single character (multibyte is okay)
+        add = "│",
+        change = "│",
+        delete = "-",
+      },
     },
     marks = {
       enable = true,

--- a/doc/satellite.txt
+++ b/doc/satellite.txt
@@ -36,6 +36,11 @@ of the default settings:
         },
         gitsigns = {
           enable = true,
+          signs = { -- can only be a single character (multibyte is okay)
+            add = "│",
+            change = "│",
+            delete = "-",
+          },
         },
         marks = {
           enable = true,

--- a/lua/satellite/config.lua
+++ b/lua/satellite/config.lua
@@ -7,6 +7,7 @@
 ---@field enable boolean
 ---@field overlap boolean
 ---@field priority integer
+---@field signs table<string, string>
 
 ---@class SearchConfig
 ---@field enable boolean
@@ -52,6 +53,11 @@ local user_config = {
       enable = true,
       overlap = false,
       priority = 20,
+      signs = {
+        add = "│",
+        change = "│",
+        delete = "-",
+      },
     },
     marks = {
       key = 'm',

--- a/lua/satellite/handlers/gitsigns.lua
+++ b/lua/satellite/handlers/gitsigns.lua
@@ -7,7 +7,11 @@ local handler = {
   name = 'gitsigns',
 }
 
-function handler.init()
+local config = {}
+
+function handler.init(config0)
+  config = config0
+
   local group = api.nvim_create_augroup('satellite_gitsigns', {})
 
   api.nvim_create_autocmd('User', {
@@ -35,8 +39,13 @@ function handler.update(bufnr, winid)
       local lnum = math.max(1, i)
       local pos = util.row_to_barpos(winid, lnum-1)
 
+      local symbol = config.signs[hunk.type]
+      if not symbol or type(symbol) ~= "string" then
+        symbol = hunk.type == 'delete' and '-' or '│'
+      end
+
       marks[pos] = {
-        symbol = hunk.type == 'delete' and '-' or '│',
+        symbol = symbol,
         highlight = hl
       }
     end


### PR DESCRIPTION
A few notes when implementing this:

- Can use `sign_getdefined("...")` (e.g. for `"GitSignsAdded"`), however there might be multiple options returned. The "length" (in quotes as `nvim_buf_set_extmark` seems to be okay with multibyte strings) of these signs might also not be `1` (which seems to be invalid), but they can be trimmed with `string.sub(...)`.
- No sanitizing of user input beyond checking that configuration values exist and that they are a `string`. Warnings will be output if the symbol ends up being too long or incorrect in some other way.
- Defaults should remain the same as they are now.
- Does not handle any other sign type than `add`, `delete`, or `change` (although `gitsigns` does offer more sign types).