### PR TITLE
fix(mark): exclude select mode from mark mapping

### DIFF
--- a/lua/satellite/autocmd/mark.lua
+++ b/lua/satellite/autocmd/mark.lua
@@ -23,7 +23,7 @@ local function mark_set_keymap(m)
   local key = config.user_config.handlers.marks.key .. m
   ---@diagnostic disable-next-line: missing-parameter
   if fn.maparg(key) == "" then
-    vim.keymap.set({ 'n', 'v' }, key, function()
+    vim.keymap.set({ 'n', 'x' }, key, function()
       exec_autocmd { key = key }
       return key
     end, { unique = true, expr = true})


### PR DESCRIPTION
Previously the `m` key was kind of blocked in the select mode, although with this patch, the select mode is excluded from the mapping.

**NOTE**: Neovim does _NOT_ set marks in select mode.