### PR TITLE
Improvements in diagnostic handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ require('satellite').setup {
     },
     diagnostic = {
       enable = true,
+      signs = {'-', '=', '≡'},
+      min_severity = vim.diagnostic.severity.HINT,
     },
     gitsigns = {
       enable = true,

--- a/doc/satellite.txt
+++ b/doc/satellite.txt
@@ -33,6 +33,8 @@ of the default settings:
         },
         diagnostic = {
           enable = true,
+          signs = {'-', '=', '≡'},
+          min_severity = vim.diagnostic.severity.HINT,
         },
         gitsigns = {
           enable = true,


### PR DESCRIPTION
# More customization in diagnostic handler

Exposed more configuration parameters (`signs` and `min_severity`). Both can be configured with `setup`:
```lua
require('satellite').setup {
    diagnostic = {
      signs = {'-', '=', '≡'},
      min_severity = vim.diagnostic.severity.HINT,
    },
}
```

# Added `min_severity` option

This option specifies the least important diagnostic that should be shown on the scroll bar. By default it is set to `HINT`, which means all diagnostics are shown. But, if set to `INFO`, it will show everything including `INFO`, but not `HINT`. Example:
- Set to `HINT`
  ![image](https://user-images.githubusercontent.com/44075969/229386805-a0f41072-3630-462c-b4b4-4d5d87efcf06.png)
- Set to `INFO`
  ![image](https://user-images.githubusercontent.com/44075969/229386890-c1203f4e-2c55-46a9-8be8-f7b572ad48bd.png)

# Better highlights

Before, the diagnostic sign was highlighted with the severity of the last diagnostic in that part of the file. Which means that, sometimes, the lines with multiple diagnostics wouldn't be highlighted properly:
- Before
  ![image](https://user-images.githubusercontent.com/44075969/229387136-e1618fc0-a4a6-4766-b539-949df532eae0.png)
  (the line has both warning and error, warning is shown on the scroll bar)
- After
  ![image](https://user-images.githubusercontent.com/44075969/229387231-a44726ba-eb9e-4324-8c6c-65874fd123ca.png)
  (error is shown on the scroll bar)