### PR TITLE
feat: add MarkSV highlight group for highlighting marks

### DIFF
--- a/lua/satellite/handlers/marks.lua
+++ b/lua/satellite/handlers/marks.lua
@@ -1,7 +1,7 @@
 local util = require'satellite.util'
 local view = require'satellite.view'
 
-local highlight = 'Normal'
+local highlight = 'MarkSV'
 
 local api = vim.api
 
@@ -11,6 +11,13 @@ require'satellite.autocmd.mark'
 local handler = {
   name = 'marks',
 }
+
+local function setup_hl()
+  api.nvim_set_hl(0, highlight, {
+    default = true,
+    fg = api.nvim_get_hl_by_name('Normal', true).foreground,
+  })
+end
 
 local BUILTIN_MARKS = { "'.", "'^", "''", "'\"", "'<", "'>", "'[", "']" }
 
@@ -31,6 +38,13 @@ function handler.init(config0)
   config = config0
 
   local group = api.nvim_create_augroup('satellite_marks', {})
+
+  api.nvim_create_autocmd('ColorScheme', {
+    group = group,
+    callback = setup_hl,
+  })
+
+  setup_hl()
 
   api.nvim_create_autocmd('User', {
     group = group,


### PR DESCRIPTION
This allows the highlight group to be changed.

This also fixes an issue where the background of the mark characters would override the scrollbar:

**Before**
![image](https://github.com/lewis6991/satellite.nvim/assets/8965202/d05c0d30-f112-4e11-9223-e4e854233f69)

**After**
![image](https://github.com/lewis6991/satellite.nvim/assets/8965202/3963b18c-fb63-489c-94bf-18c1ac6b1e32)
