### PR TITLE
fix: #62 - bump requirement docs

### DIFF
--- a/doc/satellite.txt
+++ b/doc/satellite.txt
@@ -9,7 +9,7 @@ License:  MIT license
 REQUIREMENTS                                          *satellite-requirements*
 
 * Scrollbar mouse dragging requires mouse support (see |'mouse'|) and
-  `nvim>=0.9`.
+  `nvim>=0.10`.
 
 ==============================================================================
 USAGE                                                        *satellite-usage*


### PR DESCRIPTION
Closes: #62 

Bump the minimal requirements in the help doc for neovim to nightly (v0.10+).