### PR TITLE
feat: add scrollbar background color

### DIFF
--- a/doc/satellite.txt
+++ b/doc/satellite.txt
@@ -101,10 +101,10 @@ Highlight Groups ~
 The following highlight group can be configured to change |satellite.nvim|'s
 colors.
 
-Name                   Default          Description
-----                   -------        -----------
-`SatelliteBar`           `Visual`         Color for the scrollbar
-`SatelliteBackground`    `ColorColumn`    Color for the scrollbar background
+Name                   Default      Description
+----                   -------      -----------
+`SatelliteBar`           `Visual`       Color for the scrollbar
+`SatelliteBackground`    `NONE`         Color for the scrollbar background
 
 The highlight groups can be customized. Example:
  >vim

--- a/doc/satellite.txt
+++ b/doc/satellite.txt
@@ -101,9 +101,10 @@ Highlight Groups ~
 The following highlight group can be configured to change |satellite.nvim|'s
 colors.
 
-Name         Default   Description
-----         -------   -----------
-`SatelliteBar`   `Visual`    Color for the scrollbar
+Name                   Default          Description
+----                   -------        -----------
+`SatelliteBar`           `Visual`         Color for the scrollbar
+`SatelliteBackground`    `ColorColumn`    Color for the scrollbar background
 
 The highlight groups can be customized. Example:
  >vim

--- a/lua/satellite.lua
+++ b/lua/satellite.lua
@@ -179,7 +179,6 @@ function M.setup(cfg)
   -- E.g., the following will use custom highlight colors.
   --   :highlight SatelliteBar ctermbg=159 guibg=LightCyan
   api.nvim_set_hl(0, 'SatelliteBar', { default = true, link = 'Visual' })
-  api.nvim_set_hl(0, 'SatelliteBackground', { default = true, link = 'ColorColumn'})
 
   enable()
 end

--- a/lua/satellite.lua
+++ b/lua/satellite.lua
@@ -179,6 +179,7 @@ function M.setup(cfg)
   -- E.g., the following will use custom highlight colors.
   --   :highlight SatelliteBar ctermbg=159 guibg=LightCyan
   api.nvim_set_hl(0, 'SatelliteBar', { default = true, link = 'Visual' })
+  api.nvim_set_hl(0, 'SatelliteBackground', { default = true, link = 'ColorColumn'})
 
   enable()
 end

--- a/lua/satellite/view.lua
+++ b/lua/satellite/view.lua
@@ -53,7 +53,7 @@ local function render_scrollbar(winid, bwinid)
   local bbufnr = api.nvim_win_get_buf(bwinid)
   local winheight = util.get_winheight(winid)
 
-  -- only set populate lines if we need to
+  -- Initialise buffer lines if needed
   if api.nvim_buf_line_count(bbufnr) ~= winheight then
     local lines = {} --- @type string[]
     for i = 1, winheight do
@@ -69,13 +69,21 @@ local function render_scrollbar(winid, bwinid)
   local row = vim.w[bwinid].row --- @type integer
 
   api.nvim_buf_clear_namespace(bbufnr, ns, 0, -1)
-  for i = row, row + height do
-    pcall(api.nvim_buf_set_extmark, bbufnr, ns, i, 0, {
-      virt_text = { { ' ', 'SatelliteBar' } },
-      virt_text_pos = 'overlay',
-      priority = 1,
-    })
-  end
+  -- Set bar colors with virtual text for each line.
+  for i = 0, winheight-1 do
+      -- Background color
+      local style = 'SatelliteBackground'
+      -- Bar color
+      if i >= row and i < row + height then
+        style = 'SatelliteBar'
+      end
+
+      pcall(api.nvim_buf_set_extmark, bbufnr, ns, i, 0, {
+        virt_text = { { ' ', style } },
+        virt_text_pos = 'overlay',
+        priority = 1,
+      })
+    end
 end
 
 --- Get or retrieve a bar window id for a given window


### PR DESCRIPTION
# Add configurable scrollbar background color

Close #52 

- [x] Add configurable scrollbar background highlight color via `SatelliteBackground` highlight group. Highlight set to `NONE`  by default.
- [x] Update docs

## Screenshots

White             |  White & Winblend 50 | Cyan | Cyan & Winblend 50 | Pink | Pink & Winblend 50
:-------------------------:|:-------------------------:|:-------------------------:|:-------------------------:|:-------------------------:|:-------------------------:
![White](https://github.com/lewis6991/satellite.nvim/assets/38880939/c3178db3-0e76-4861-b406-95b147c766b2)  |  ![White + Winblend 50](https://github.com/lewis6991/satellite.nvim/assets/38880939/28136592-3aed-4998-8930-a5edb0f0d53b) | ![Cyan](https://github.com/lewis6991/satellite.nvim/assets/38880939/82fe26fd-2377-4666-bf4a-a264c2a02f60) | ![Cyan + Winblend 50](https://github.com/lewis6991/satellite.nvim/assets/38880939/42dacd0a-09b2-47e4-b620-3cdc2cb28fb5) | ![Pink](https://github.com/lewis6991/satellite.nvim/assets/38880939/3383882d-a0e2-46f2-ae1e-c17a57d8de6e) | ![Pink + Winblend 50](https://github.com/lewis6991/satellite.nvim/assets/38880939/3a61dc58-70d7-414a-9ea8-861272e0cd5b)

## Potential Issues

- Background color may conflict with mark highlights.
- The additional bar for marks not combined in the scrollbar is not updated. Although I notice the bar highlight representing the current view of the buffer is not used there also.