### PR TITLE
Feat/show always

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ function. Here is an example with most of the default settings:
 ```lua
 require('satellite').setup {
   current_only = false,
+  show_always = false,
   winblend = 50,
   zindex = 40,
   excluded_filetypes = {},

--- a/doc/satellite.txt
+++ b/doc/satellite.txt
@@ -23,6 +23,7 @@ of the default settings:
 >lua
     require('satellite').setup {
       current_only = false,
+      show_always = false,
       winblend = 50,
       zindex = 40,
       excluded_filetypes = {},
@@ -82,6 +83,13 @@ excluded_filetypes                       *satellite-config-excluded_filetypes*
         Default: `[]`
 
         File types for which scrollbars should not be displayed.
+
+show_always                                     *satellite-config-show_always*
+        Type: `boolean`
+        Default: `false`
+
+        If true, scrollbars will show even if buffers are drawn without
+        cut-off.
 
 winblend                                           *satellite-config-winblend*
         Type: `integer`

--- a/lua/satellite/config.lua
+++ b/lua/satellite/config.lua
@@ -20,12 +20,14 @@
 --- @class SatelliteConfig
 --- @field handlers HandlerConfigs
 --- @field current_only boolean
+--- @field show_always boolean
 --- @field winblend integer
 --- @field zindex integer
 --- @field excluded_filetypes string[]
 local user_config = {
   handlers = {},
   current_only = false,
+  show_always = false,
   winblend = 50,
   zindex = 40,
   excluded_filetypes = {},

--- a/lua/satellite/mouse.lua
+++ b/lua/satellite/mouse.lua
@@ -362,7 +362,7 @@ function M.handle_leftmouse()
           return
         end
         -- row is 1-based (see getmousepos()), so need to pass in 0-based
-        local row0 = math.max(0, math.min(row - 1, winheight - props.height))
+        local row0 = math.max(0, math.min(row, winheight - props.height))
         -- Only update scrollbar if the row changed.
         if props.row ~= row0 then
           local bufnr = api.nvim_win_get_buf(winid)

--- a/lua/satellite/mouse.lua
+++ b/lua/satellite/mouse.lua
@@ -361,7 +361,6 @@ function M.handle_leftmouse()
         if not props then
           return
         end
-        -- row is 1-based (see getmousepos()), so need to pass in 0-based
         local row0 = math.max(0, math.min(row, winheight - props.height))
         -- Only update scrollbar if the row changed.
         if props.row ~= row0 then

--- a/lua/satellite/view.lua
+++ b/lua/satellite/view.lua
@@ -180,8 +180,9 @@ local function can_show_scrollbar(winid)
   end
 
   -- Don't show the position bar when all lines are on screen.
+  -- Will show the bar if `show_always` is true regardless of lines on screen.
   local topline, botline = util.visible_line_range(winid)
-  if botline - topline + 1 == line_count then
+  if not user_config.show_always and botline - topline + 1 == line_count then
     return false
   end
 


### PR DESCRIPTION
Added option `show_always` which, when set to `true` will always show the scroll bar even if the buffer can be displayed at once.
By default set to `false`.

(Should have) close(d) issue #73