### PR TITLE
fix: show markers when there are multiple diagnostic namespaces.

### DIFF
--- a/lua/satellite/handlers/diagnostic.lua
+++ b/lua/satellite/handlers/diagnostic.lua
@@ -61,7 +61,7 @@ function handler.setup(config0, update)
       --- vim.diagnostic.get() is expensive as it runs vim.deepcopy() on every
       --- call. Keep a local copy that is only updated when diagnostics change.
       local bufnr = args.buf
-      buf_diags[bufnr] = args.data.diagnostics
+      buf_diags[bufnr] = vim.diagnostic.get(bufnr)
 
       vim.schedule(update)
     end,


### PR DESCRIPTION
Previously we were quashing potential other diagnostics if, e.g., only one diagnostic namespace updated (which fires this event).

In other words: not all current diagnostics are present in args.data, that's just diagnostics for the most recent namespace potentially.

Closes: #84