### PR TITLE
Override global `winborder` option

### DIFF
--- a/lua/satellite/view.lua
+++ b/lua/satellite/view.lua
@@ -94,6 +94,7 @@ local function get_or_create_view(winid)
     win = winid,
     relative = 'win',
     style = 'minimal',
+    border = 'none',
     focusable = false,
     zindex = user_config.zindex,
     width = 1,


### PR DESCRIPTION
Neovim v0.11.0 introduced a `winborder` option. When the user specifies it, it will be also used for the scroll bar. This PR fixes that problem