### PR TITLE
fix: schedule update and close vim.api calls

### DIFF
--- a/lua/satellite/handlers.lua
+++ b/lua/satellite/handlers.lua
@@ -180,7 +180,7 @@ function M.init()
     end
   end
 
-  local update = require('satellite.view').refresh_bars
+  local update = vim.schedule_wrap(require('satellite.view').refresh_bars)
 
   -- Initialize handlers
   for _, h in ipairs(M.handlers) do

--- a/lua/satellite/view.lua
+++ b/lua/satellite/view.lua
@@ -240,7 +240,11 @@ local function close(winid)
   if util.in_cmdline_win(winid) then
     return
   end
-  util.noautocmd(api.nvim_win_close)(bar_winid, true)
+  vim.schedule(function()
+    if api.nvim_win_is_valid(bar_winid) then
+      util.noautocmd(api.nvim_win_close)(bar_winid, true)
+    end
+  end)
   winids[winid] = nil
 end
 


### PR DESCRIPTION
Depending on surrounding circumstances, these callbacks may be in an luv-event-loop which yields errors when invoking these api. Wrap and schedule the offending calls to defer the callbacks, fixing the crashes.

Credits to QuiiBz

Fixes #90